### PR TITLE
add an optional configuration file

### DIFF
--- a/usermin-init
+++ b/usermin-init
@@ -11,6 +11,10 @@
 # Description: Start or stop the Usermin server
 ### END INIT INFO
 
+if [ -f /etc/sysconfig/usermin ]; then
+        . /etc/sysconfig/usermin
+fi
+
 start=/etc/usermin/start
 stop=/etc/usermin/stop
 lockfile=/var/lock/subsys/usermin


### PR DESCRIPTION
this technique is used in most of the init scripts in redhat/centos to add additional configuration loaded before init like ulimit