### PR TITLE
Automate install + OpenSSL version checking

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -409,8 +409,11 @@ else
 	echo "ssl=$ssl" >> $cfile
 	echo "no_ssl2=1" >> $cfile
 	echo "no_ssl3=1" >> $cfile
-	echo "no_tls1=1" >> $cfile
-	echo "no_tls1_1=1" >> $cfile    
+	openssl version 2>&1 | grep "OpenSSL 1" 2>&1 >/dev/null
+	if [ "$?" == "0" ]; then
+		echo "no_tls1=1" >> $cfile
+		echo "no_tls1_1=1" >> $cfile    
+	fi
 	echo "env_WEBMIN_CONFIG=$config_dir" >> $cfile
 	echo "env_WEBMIN_VAR=$var_dir" >> $cfile
 	echo "atboot=$atboot" >> $cfile

--- a/setup.sh
+++ b/setup.sh
@@ -78,6 +78,11 @@ if [ "$allmods" = "" ]; then
 fi
 echo ""
 
+# Load package-defined variable overrides
+if [ -r "$srcdir/setup-pre.sh" ]; then
+        . "$srcdir/setup-pre.sh"
+fi
+
 # Ask for usermin config directory
 echo "***********************************************************************"
 echo "Usermin uses separate directories for configuration files and log files."
@@ -405,7 +410,7 @@ else
 	echo "no_ssl2=1" >> $cfile
 	echo "no_ssl3=1" >> $cfile
 	echo "no_tls1=1" >> $cfile
-	echo "no_tls1_1=1" >> $cfile
+	echo "no_tls1_1=1" >> $cfile    
 	echo "env_WEBMIN_CONFIG=$config_dir" >> $cfile
 	echo "env_WEBMIN_VAR=$var_dir" >> $cfile
 	echo "atboot=$atboot" >> $cfile


### PR DESCRIPTION
These two basic changes are already in Webmin, but are not in Usermin.

The first (automated input values) comes from the initial checkin of Webmin.
The second comes from: [Don't disable TLS 1.0 and 1.1 on old openssl versions, as they may not support newer protocols](https://github.com/webmin/webmin/commit/ba53820a46a43598d47484a04e87425db4fcffac)