### PR TITLE
run setup-post.sh like webmin does and add noportcheck variable

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -351,11 +351,13 @@ else
 		echo ""
 		exit 12
 	fi
-	$perl -e 'use Socket; socket(FOO, PF_INET, SOCK_STREAM, getprotobyname("tcp")); setsockopt(FOO, SOL_SOCKET, SO_REUSEADDR, pack("l", 1)); bind(FOO, pack_sockaddr_in($ARGV[0], INADDR_ANY)) || exit(1); exit(0);' $port
-	if [ $? != "0" ]; then
-		echo "ERROR: TCP port $port is already in use by another program"
-		echo ""
-		exit 13
+	if [ "$noportcheck" = "" ]; then
+		$perl -e 'use Socket; socket(FOO, PF_INET, SOCK_STREAM, getprotobyname("tcp")); setsockopt(FOO, SOL_SOCKET, SO_REUSEADDR, pack("l", 1)); bind(FOO, pack_sockaddr_in($ARGV[0], INADDR_ANY)) || exit(1); exit(0);' $port
+		if [ $? != "0" ]; then
+			echo "ERROR: TCP port $port is already in use by another program"
+			echo ""
+			exit 13
+		fi
 	fi
 
 	# Ask the user if SSL should be used

--- a/setup.sh
+++ b/setup.sh
@@ -647,6 +647,11 @@ else
 	rm -f $config_dir/install-dir
 fi
 
+# Run package-defined post-install script
+if [ -r "$srcdir/setup-post.sh" ]; then
+	. "$srcdir/setup-post.sh"
+fi
+
 if [ "$nostart" = "" ]; then
 	if [ "$inetd" != "1" ]; then
 		echo "Attempting to start Usermin mini web server.."


### PR DESCRIPTION
Webmin runs setup-pre.sh and setup-post.sh

but Usermin runs just setup-pre.sh. So add support for setup-post.sh too

Also when usermin is already running (say on port 20000) then running setup.sh (for packaging) exits with error code 13 (exit 13) saying that port 20000 is already in use.

So patch adds noportcheck variable. Which can be set so that it does not check if port is in use.