### PR TITLE
Wrong redirect

### DIFF
--- a/cshrc/save_cshrc.cgi
+++ b/cshrc/save_cshrc.cgi
@@ -9,5 +9,5 @@ $in{'cshrc'} =~ s/\r//g;
 &open_tempfile(CSHRC, ">".$cshrc_files[$in{'idx'}]);
 &print_tempfile(CSHRC, $in{'cshrc'});
 &close_tempfile(CSHRC);
-&redirect("/");
+&redirect("");
 


### PR DESCRIPTION
In case it's done this way, redirect happens to the localhost:10000/ - breaking everything.

In Authentic Theme things just don't load and show empty screen and in Gray Theme, redirect happens to root and produces frame in frame buggy output.