### PR TITLE
extend desc-link.sh to find also missing translations, update de, nl fr

### DIFF
--- a/at/module.info.fr
+++ b/at/module.info.fr
@@ -1,0 +1,1 @@
+../../webadmin/at/module.info.fr

--- a/desc-link.sh
+++ b/desc-link.sh
@@ -33,7 +33,7 @@ parameters:
 
 how to:
 	- checkout usermin and webmin from github:
-	  # git clone https://github.com/<YOURNAME>/webmin.git
+	  # git clone https://github.com/<YOURNAME>/webmin.git webadmin
 	  # git clone https://github.com/<YOURNAME>/usermin.git
 	- cd to usermin and run script
 	  # cd usermin; $0 de
@@ -93,7 +93,7 @@ do
 	then
 		echo "linking $file -> $WEBMIN/$file"
 		[ -f "$file" ] && mv $file $file.sav 
-		ln -s ../$WEBMIN/$file $file
+		ln -s ../webadmin/$file $file
 		if [ $? -ne 0 ]; then
 			[ -f "$file.sav" ] && mv $file.sav $file
 			echo "linking failed!"

--- a/desc-link.sh
+++ b/desc-link.sh
@@ -29,7 +29,7 @@ parameters:
 	force
 		link all found possibilities
 	LANG
-		language code to process, e.g. de fr
+		language code to process, e.g. $LANG 
 
 how to:
 	- checkout usermin and webmin from github:
@@ -42,6 +42,8 @@ how to:
 	  # git push
 	
 EOF
+	echo "availible languages:"
+	( cd $WEBMIN/lang; ls )
 	exit
 fi
 
@@ -86,10 +88,8 @@ do
 	if [ "$FORCE" == "" ]
 	then
 		read ans
-	else
-		ans="l"
 	fi
-	if [ "$ans" = "l" ]
+	if [ "$ans" == "l" -o "$FORCE" != "" ]
 	then
 		echo "linking $file -> $WEBMIN/$file"
 		[ -f "$file" ] && mv $file $file.sav 
@@ -102,7 +102,7 @@ do
 			rm -f $file.sav
 		fi
 	fi
-	if [ "$ans" = "e" ]
+	if [ "$ans" == "e" ]
 	then
 		echo "editing $WEBMIN/$file"
 		${EDITOR} $WEBMIN/$file

--- a/desc-link.sh
+++ b/desc-link.sh
@@ -2,13 +2,57 @@
 # support translators to check their module.info.lang files
 # and decide if they can linked to existing webadmin version
 [ "$EDITOR" == "" ] && EDITOR=vi
-WEBMIN="../webadmin"
+FORCE=""
+WEBMIN="../webmin"
+[ -d "../webadmin" ] && WEBMIN="../webadmin"
 
 if [ ! -d $WEBMIN ]
 then
-	echo "$WEBMIN not found!"
+	echo "webmin not found! please check out webmin from github."
 	exit 1
 fi
+
+# help
+if [ "$1" == "-h" ]
+then
+	cat <<EOF
+
+usage: $0 [-force] LANG
+
+	this script helps translators to find out if descriptions
+	for a given language already exsits in webmin and offers to:
+
+	link	same description is used for webmin and usermin
+	edit	edit description in webmin to fit both
+
+parameters:
+	force
+		link all found possibilities
+	LANG
+		language code to process, e.g. de fr
+
+how to:
+	- checkout usermin and webmin from github:
+	  # git clone https://github.com/<YOURNAME>/webmin.git
+	  # git clone https://github.com/<YOURNAME>/usermin.git
+	- cd to usermin and run script
+	  # cd usermin; $0 de
+	- push changes to repository
+	  # git add; git commit -m "LANG xx"
+	  # git push
+	
+EOF
+	exit
+fi
+
+
+# check for force
+if [ "$1" == "-force" ]
+then
+	FORCE="yes"
+	shift
+fi
+
 
 # $1 is LAMNG to check
 if [ "$1" == "" ]
@@ -19,17 +63,19 @@ then
 	exit 1
 fi
 
+LANG=$1
+
 #get lang files
 for module in `ls */module.info 2>/dev/null`
 do
-	file="$module.$1"
+	file="$module.$LANG"
 	# skip if wbebmin/file not exsit ort already symlinked 
 	[ ! -f "$WEBMIN/$file" -o -h "$file" ] && continue
 
 	echo -e "\nprocessing file -> $file\n--------------------"
 	if [ ! -f "$file" ]
 	then
-		echo " -> missing translation for \"$1\" found!"
+		echo " -> missing translation for \"$LANG\" found!"
 	else
 		cat $file
 	fi
@@ -37,7 +83,12 @@ do
 	cat ../webadmin/$file
 
 	echo -n -e "\nselect action: [e]dit webmin file, [l]ink, [S]kip ?\b"
-	read ans
+	if [ "$FORCE" == "" ]
+	then
+		read ans
+	else
+		ans="l"
+	fi
 	if [ "$ans" = "l" ]
 	then
 		echo "linking $file -> $WEBMIN/$file"

--- a/desc-link.sh
+++ b/desc-link.sh
@@ -20,13 +20,19 @@ then
 fi
 
 #get lang files
-for file in `ls */module.info.$1 2>/dev/null`
+for module in `ls */module.info 2>/dev/null`
 do
+	file="$module.$1"
 	# skip if wbebmin/file not exsit ort already symlinked 
 	[ ! -f "$WEBMIN/$file" -o -h "$file" ] && continue
 
 	echo -e "\nprocessing file -> $file\n--------------------"
-	cat $file
+	if [ ! -f "$file" ]
+	then
+		echo " -> missing translation for \"$1\" found!"
+	else
+		cat $file
+	fi
 	echo -e "\nwebmin file -> $WEBMIN/$file \n--------------------"
 	cat ../webadmin/$file
 
@@ -35,10 +41,10 @@ do
 	if [ "$ans" = "l" ]
 	then
 		echo "linking $file -> $WEBMIN/$file"
-		mv $file $file.sav
+		[ -f "$file" ] && mv $file $file.sav 
 		ln -s ../$WEBMIN/$file $file
 		if [ $? -ne 0 ]; then
-			mv $file.sav $file
+			[ -f "$file.sav" ] && mv $file.sav $file
 			echo "linking failed!"
 		else
 			echo -e "done!\n"

--- a/mailcap/module.info.de
+++ b/mailcap/module.info.de
@@ -1,0 +1,1 @@
+../../webadmin/mailcap/module.info.de

--- a/mysql/module.info.fr
+++ b/mysql/module.info.fr
@@ -1,0 +1,1 @@
+../../webadmin/mysql/module.info.fr

--- a/mysql/module.info.nl
+++ b/mysql/module.info.nl
@@ -1,1 +1,1 @@
-desc_nl=MySQL Database
+../../webadmin/mysql/module.info.nl

--- a/postgresql/module.info.fr
+++ b/postgresql/module.info.fr
@@ -1,0 +1,1 @@
+../../webadmin/postgresql/module.info.fr

--- a/postgresql/module.info.nl
+++ b/postgresql/module.info.nl
@@ -1,0 +1,1 @@
+../../webadmin/postgresql/module.info.nl

--- a/procmail/module.info.fr
+++ b/procmail/module.info.fr
@@ -1,0 +1,1 @@
+../../webadmin/procmail/module.info.fr

--- a/updown/module.info.fr
+++ b/updown/module.info.fr
@@ -1,0 +1,1 @@
+../../webadmin/updown/module.info.fr


### PR DESCRIPTION
The script `desc-link.sh` now also look for description translations which exists in webmin but not usermin and offer to link them.

Usermin has now 8 more transalted description since last version of the script :-)

Can be merged upfront or after new release ...