### PR TITLE
chmod only directories not files inside

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -626,7 +626,7 @@ fi
 
 echo "Changing ownership and permissions .."
 chown -R root:bin $config_dir
-chmod -R 755 $config_dir
+find $config_dir -type d -exec chmod 755 {} +
 if [ "$nochown" = "" ]; then
 	chown -R root:bin "$wadir"
 	chmod -R og-w "$wadir"


### PR DESCRIPTION
This fixes execute permission given to all files. Instead it sets execute bit only on directories.

"find" command is portable and is already used at other places in setup.sh