### PR TITLE
Strict mode error

### DIFF
--- a/mailbox/index.cgi
+++ b/mailbox/index.cgi
@@ -6,6 +6,7 @@ use warnings;
 our (%text, %in, %userconfig, %config);
 our ($remote_user, $remote_pass);
 our $special_folder_id;
+our $plen;
 our ($cb); # XXX
 
 require './mailbox-lib.pl';


### PR DESCRIPTION
Global symbol "$plen" requires explicit package name (did you forget to declare "my $plen"?) at /usr/share/usermin/mailbox/index.cgi line 246. Global symbol "$plen" requires explicit package name (did you forget to declare "my $plen"?) at /usr/share/usermin/mailbox/index.cgi line 248. BEGIN not safe after errors--compilation aborted at /usr/share/usermin/mailbox/index.cgi line 317.