### PR TITLE
Add Usermin to use native `systemd` service file

### DIFF
--- a/makedist.pl
+++ b/makedist.pl
@@ -21,7 +21,7 @@ $vers = $ARGV[0];
 	  "group_chooser.cgi", "config-irix", "config-osf1", "thirdparty.pl",
 	  "oschooser.pl", "config-unixware",
 	  "config-openserver", "switch_user.cgi", "lang", "ulang",
-	  "lang_list.txt", "usermin-init", "usermin-daemon",
+	  "lang_list.txt", "usermin-systemd", "usermin-init", "updateboot.pl",
 	  "config-openbsd",
 	  "config-macos", "LICENCE",
 	  "session_login.cgi",

--- a/setup.sh
+++ b/setup.sh
@@ -598,8 +598,6 @@ if [ -x "$systemctlcmd" ]; then
 	echo "#!/bin/sh" >>$config_dir/reload
 	echo "$config_dir/.reload-init >/dev/null 2>&1" >>$config_dir/reload
 
-	# Fix existing systemd usermin.service file to update start and stop commands
-	(cd "$wadir" ; WEBMIN_CONFIG=$config_dir WEBMIN_VAR=$var_dir "$wadir/updateboot.pl")
 	
 	chmod 755 $config_dir/stop $config_dir/start $config_dir/restart $config_dir/restart-by-force-kill $config_dir/reload
 else
@@ -608,6 +606,10 @@ else
 fi
 echo "..done"
 echo ""
+
+# Fix existing init file to update start and stop commands
+(cd "$wadir" ; WEBMIN_CONFIG=$config_dir WEBMIN_VAR=$var_dir "$wadir/updateboot.pl")
+cd "$wadir"
 
 if [ "$upgrading" = 1 ]; then
 	echo "Updating config files.."

--- a/setup.sh
+++ b/setup.sh
@@ -575,7 +575,7 @@ ln -s $config_dir/.restart-by-force-kill-init $config_dir/restart-by-force-kill 
 ln -s $config_dir/.reload-init $config_dir/reload >/dev/null 2>&1
 
 # For systemd create different start/stop scripts
-systemctlcmd=`which systemctl` >/dev/null 2>&1
+systemctlcmd=`which systemctl 2>/dev/null`
 if [ -x "$systemctlcmd" ]; then
 	rm -f $config_dir/stop $config_dir/start $config_dir/restart $config_dir/restart-by-force-kill $config_dir/reload
 

--- a/setup.sh
+++ b/setup.sh
@@ -499,33 +499,113 @@ if [ "$noperlpath" = "" ]; then
 	echo ""
 fi
 
-echo "Creating start and stop scripts.."
-rm -f $config_dir/stop $config_dir/start
-echo "#!/bin/sh" >>$config_dir/start
-echo "echo Starting Usermin server in $wadir" >>$config_dir/start
-echo "trap '' 1" >>$config_dir/start
-echo "LANG=" >>$config_dir/start
-echo "export LANG" >>$config_dir/start
-echo "#PERLIO=:raw" >>$config_dir/start
-echo "unset PERLIO" >>$config_dir/start
-echo "export PERLIO" >>$config_dir/start
+# Re-generating main
+rm -f $config_dir/.stop-init $config_dir/.start-init $config_dir/.restart-init $config_dir/.restart-by-force-kill-init $config_dir/.reload-init
+echo "Creating start and stop init scripts.."
+# Start main
+echo "#!/bin/sh" >>$config_dir/.start-init
+echo "echo Starting Usermin server in $wadir" >>$config_dir/.start-init
+echo "trap '' 1" >>$config_dir/.start-init
+echo "LANG=" >>$config_dir/.start-init
+echo "export LANG" >>$config_dir/.start-init
+echo "unset PERLIO" >>$config_dir/.start-init
+echo "export PERLIO" >>$config_dir/.start-init
+echo "PERLLIB=$PERLLIB" >>$config_dir/.start-init
+echo "export PERLLIB" >>$config_dir/.start-init
 uname -a | grep -i 'HP/*UX' >/dev/null
 if [ $? = "0" ]; then
-	echo "exec "$wadir/miniserv.pl" $config_dir/miniserv.conf &" >>$config_dir/start
+	echo "exec '$wadir/miniserv.pl' \$* $config_dir/miniserv.conf &" >>$config_dir/.start-init
 else
-	uname -a | grep -i FreeBSD >/dev/null
-	if [ "$?" = "0" ]; then
-		echo "LD_PRELOAD=`echo /usr/lib/libpam.so.?`" >>$config_dir/start
-		echo "export LD_PRELOAD" >>$config_dir/start
-	fi
-	echo "exec "$wadir/miniserv.pl" $config_dir/miniserv.conf" >>$config_dir/start
+	echo "exec '$wadir/miniserv.pl' \$* $config_dir/miniserv.conf" >>$config_dir/.start-init
 fi
+# Stop main
+echo "#!/bin/sh" >>$config_dir/.stop-init
+echo "if [ \"\$1\" = \"--kill\" ]; then" >>$config_dir/.stop-init
+echo "  echo Force stopping Usermin server in $wadir" >>$config_dir/.stop-init
+echo "else" >>$config_dir/.stop-init
+echo "  echo Stopping Usermin server in $wadir" >>$config_dir/.stop-init
+echo "fi" >>$config_dir/.stop-init
+echo "pidfile=\`grep \"^pidfile=\" $config_dir/miniserv.conf | sed -e 's/pidfile=//g'\`" >>$config_dir/.stop-init
+echo "pid=\`cat \$pidfile\` 2>/dev/null" >>$config_dir/.stop-init
+echo "if [ \"\$pid\" != \"\" ]; then" >>$config_dir/.stop-init
+echo "  kill \$pid || exit 1" >>$config_dir/.stop-init
+echo "  touch $var_dir/stop-flag" >>$config_dir/.stop-init
+echo "  if [ \"\$1\" = \"--kill\" ]; then" >>$config_dir/.stop-init
+echo "    sleep 1" >>$config_dir/.stop-init
+echo "    ((ps axf | grep \"usermin\/miniserv\.pl\" | awk '{print \"kill -9 -- -\" \$1}' | bash) || kill -9 -- -\$pid || kill -9 \$pid) 2>/dev/null" >>$config_dir/.stop-init
+echo "  fi" >>$config_dir/.stop-init
+echo "  exit 0" >>$config_dir/.stop-init
+echo "else" >>$config_dir/.stop-init
+echo "  if [ \"\$1\" = \"--kill\" ]; then" >>$config_dir/.stop-init
+echo "    (ps axf | grep \"usermin\/miniserv\.pl\" | awk '{print \"kill -9 -- -\" \$1}' | bash) 2>/dev/null" >>$config_dir/.stop-init
+echo "  fi" >>$config_dir/.stop-init
+echo "fi" >>$config_dir/.stop-init
+# Restart main
+echo "#!/bin/sh" >>$config_dir/.restart-init
+echo "$config_dir/.stop-init" >>$config_dir/.restart-init
+echo "$config_dir/.start-init" >>$config_dir/.restart-init
+# Force reload main
+echo "#!/bin/sh" >>$config_dir/.restart-by-force-kill-init
+echo "$config_dir/.stop-init --kill" >>$config_dir/.restart-by-force-kill-init
+echo "$config_dir/.start-init" >>$config_dir/.restart-by-force-kill-init
+# Reload main
+echo "#!/bin/sh" >>$config_dir/.reload-init
+echo "echo Reloading Usermin server in $wadir" >>$config_dir/.reload-init
+echo "pidfile=\`grep \"^pidfile=\" $config_dir/miniserv.conf | sed -e 's/pidfile=//g'\`" >>$config_dir/.reload-init
+echo "kill -USR1 \`cat \$pidfile\`" >>$config_dir/.reload-init
 
-echo "#!/bin/sh" >>$config_dir/stop
-echo "echo Stopping Usermin server in $wadir" >>$config_dir/stop
-echo "pidfile=\`grep \"^pidfile=\" $config_dir/miniserv.conf | sed -e 's/pidfile=//g'\`" >>$config_dir/stop
-echo "kill \`cat \$pidfile\`" >>$config_dir/stop
-chmod 755 $config_dir/start $config_dir/stop
+chmod 755 $config_dir/.stop-init $config_dir/.start-init $config_dir/.restart-init $config_dir/.restart-by-force-kill-init $config_dir/.reload-init
+echo "..done"
+echo ""
+
+# Re-generating supplementary
+
+# Clear existing
+rm -f $config_dir/stop $config_dir/start $config_dir/restart $config_dir/restart-by-force-kill $config_dir/reload
+
+# Start init.d
+ln -s $config_dir/.start-init $config_dir/start >/dev/null 2>&1
+# Stop init.d
+ln -s $config_dir/.stop-init $config_dir/stop >/dev/null 2>&1
+# Restart init.d
+ln -s $config_dir/.restart-init $config_dir/restart >/dev/null 2>&1
+# Force reload init.d
+ln -s $config_dir/.restart-by-force-kill-init $config_dir/restart-by-force-kill >/dev/null 2>&1
+# Reload init.d
+ln -s $config_dir/.reload-init $config_dir/reload >/dev/null 2>&1
+
+# For systemd create different start/stop scripts
+systemctlcmd=`which systemctl` >/dev/null 2>&1
+if [ -x "$systemctlcmd" ]; then
+	rm -f $config_dir/stop $config_dir/start $config_dir/restart $config_dir/restart-by-force-kill $config_dir/reload
+
+	echo "Creating start and stop scripts (systemd).."
+	# Start systemd
+	echo "#!/bin/sh" >>$config_dir/start
+	echo "$systemctlcmd start usermin" >>$config_dir/start
+	# Stop systemd
+	echo "#!/bin/sh" >>$config_dir/stop
+	echo "$systemctlcmd stop usermin" >>$config_dir/stop
+	# Restart systemd
+	echo "#!/bin/sh" >>$config_dir/restart
+	echo "$systemctlcmd restart usermin" >>$config_dir/restart
+	# Force reload systemd
+	echo "#!/bin/sh" >>$config_dir/restart-by-force-kill
+	echo "$config_dir/.stop-init --kill >/dev/null 2>&1" >>$config_dir/restart-by-force-kill
+	echo "$systemctlcmd stop usermin" >>$config_dir/restart-by-force-kill
+	echo "$systemctlcmd start usermin" >>$config_dir/restart-by-force-kill
+	# Reload systemd
+	echo "#!/bin/sh" >>$config_dir/reload
+	echo "$config_dir/.reload-init >/dev/null 2>&1" >>$config_dir/reload
+
+	# Fix existing systemd usermin.service file to update start and stop commands
+	(cd "$wadir" ; WEBMIN_CONFIG=$config_dir WEBMIN_VAR=$var_dir "$wadir/updateboot.pl")
+	
+	chmod 755 $config_dir/stop $config_dir/start $config_dir/restart $config_dir/restart-by-force-kill $config_dir/reload
+else
+	# Creating symlinks
+	echo "Creating start and stop init symlinks to scripts .."
+fi
 echo "..done"
 echo ""
 
@@ -615,7 +695,7 @@ if [ "\$answer" = "y" ]; then
 	echo "Deleting $wadir .."
 	rm -rf "$wadir"
 	echo "Deleting $config_dir .."
-	rm -rf $config_dir
+	rm -rf "$config_dir"
 	echo "Done!"
 fi
 EOF

--- a/updateboot.pl
+++ b/updateboot.pl
@@ -1,0 +1,54 @@
+#!/usr/bin/perl
+# updateboot.pl
+# Called by setup.sh to update boot script
+
+$no_acl_check++;
+$product = 'usermin';
+
+BEGIN { push(@INC, "."); };
+use WebminCore;
+&init_config();
+
+$< == 0 || die "updateboot.pl must be run as root";
+
+# Update boot script
+if (-d "/etc/systemd" &&
+    &has_command("systemctl") &&
+    &execute_command("systemctl list-units") == 0) {
+	# Delete all possible service files
+	my $systemd_root = &get_systemd_root();
+	foreach my $p (
+	        "/etc/systemd/system",
+	        "/usr/lib/systemd/system",
+	        "/lib/systemd/system") {
+	    unlink("$p/$product.service");
+	    unlink("$p/$product");
+	    }
+	copy_source_dest("usermin-systemd", "$systemd_root/$product.service");
+	system("systemctl daemon-reload >/dev/null 2>&1");
+	}
+elsif (-d "/etc/init.d") {
+	copy_source_dest("usermin-init", "/etc/init.d/$product");
+	}
+
+sub get_systemd_root
+{
+my ($name) = @_;
+if ($name) {
+	foreach my $p (
+		"/etc/systemd/system",
+		"/usr/lib/systemd/system",
+		"/lib/systemd/system") {
+		if (-r "$p/$name.service" || -r "$p/$name") {
+			return $p;
+			}
+		}
+	}
+if (-d "/etc/systemd/system") {
+	return "/etc/systemd/system";
+	}
+if (-d "/usr/lib/systemd/system") {
+	return "/usr/lib/systemd/system";
+	}
+return "/lib/systemd/system";
+}

--- a/usermin-init
+++ b/usermin-init
@@ -17,16 +17,17 @@ PATH=/sbin:/usr/sbin:/bin:/usr/bin
 DESC="web-based account administration interface for Unix systems"
 NAME=Usermin
 PIDFILE=/var/usermin/miniserv.pid
-SCRIPTNAME=/etc/init.d/$NAME
-START=/etc/usermin/start
-STOP=/etc/usermin/stop
-RELOAD=/etc/usermin/reload
+SCRIPTNAME=/etc/init.d/usermin
+START=/etc/usermin/.start-init
+STOP=/etc/usermin/.stop-init
+FORCERESTART=/etc/usermin/.restart-by-force-kill-init
+RELOAD=/etc/usermin/.reload-init
 LOCKFILE=/var/lock/subsys/usermin
 CONFFILE=/etc/usermin/miniserv.conf
 
 case "$1" in
 start)
-	$START >/dev/null 2>&1 </dev/null
+	$START
 	RETVAL=$?
 	if [ "$RETVAL" = "0" ]; then
 		touch $LOCKFILE >/dev/null 2>&1
@@ -37,12 +38,12 @@ stop)
 	RETVAL=$?
 	if [ "$RETVAL" = "0" ]; then
 		rm -f $LOCKFILE
+		pidfile=`grep "^pidfile=" $CONFFILE | sed -e 's/pidfile=//g'`
+		if [ "$pidfile" = "" ]; then
+			pidfile=$PIDFILE
+		fi
+		rm -f $pidfile
 	fi
-	pidfile=`grep "^pidfile=" $CONFFILE | sed -e 's/pidfile=//g'`
-	if [ "$pidfile" = "" ]; then
-		pidfile=$PIDFILE
-	fi
-	rm -f $pidfile
 	;;
 status)
 	pidfile=`grep "^pidfile=" $CONFFILE | sed -e 's/pidfile=//g'`
@@ -68,12 +69,16 @@ restart)
 	$STOP ; $START
 	RETVAL=$?
 	;;
+restart-by-force-kill)
+	$FORCERESTART
+	RETVAL=$?
+	;;
 reload|force-reload)
 	$RELOAD
 	RETVAL=$?
 	;;
 *)
-	echo "Usage: $0 {start|stop|restart|reload|force-reload|status}" >&2
+	echo "Usage: $0 {start|stop|restart|restart-by-force-kill|reload|force-reload|status}" >&2
 	RETVAL=1
 	;;
 esac

--- a/usermin-systemd
+++ b/usermin-systemd
@@ -1,0 +1,13 @@
+[Unit]
+Description=Usermin server daemon
+After=syslog.target
+
+[Service]
+ExecStart=/etc/usermin/.start-init
+ExecStop=/etc/usermin/.stop-init
+PIDFile=/var/usermin/miniserv.pid
+Type=forking
+KillMode=none
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
@jcameron Jamie, familiar PR but this time for Usermin. It will create init scripts for `systemd` and `init` systems. It is not clear how to do this for the other systems, as Usermin doesn't have access to `init` module and `init/atboot.pl` file.

I assume other fancy systems would have to call `/etc/usermin/start` and `/etc/usermin/stop`, unless we are ready to port more functionality from `init-lib.pl` to handle other, older/different systems.

I only tested it on `systemd` systems (Alma 8 and Debian 11) and CentOS 6.