### PR TITLE
Fix SELinux labeling for Usermin runtime data

### DIFF
--- a/makerpm.pl
+++ b/makerpm.pl
@@ -254,6 +254,9 @@ if [ "\$1" = 0 ]; then
 	if [ "\$?" = 0 ]; then
 		# RPM is being removed, and no new version of usermin
 		# has taken it's place. Delete the config files
+		if command -v semanage >/dev/null 2>&1; then
+			semanage fcontext -d "/var/usermin(/.*)?" >/dev/null 2>&1 || true
+		fi
 		rm -rf /etc/usermin /var/usermin
 		systemctlcmd=\`which systemctl 2>/dev/null\`
 		if [ -x "\$systemctlcmd" ]; then

--- a/makerpm.pl
+++ b/makerpm.pl
@@ -207,11 +207,8 @@ if [ "\\\$answer" = "y" ]; then
 	echo "Removing Usermin RPM .."
 	rm -f /usr/libexec/usermin/authentic-theme/manifest-*
 	rpm -e --nodeps usermin
-	systemctlcmd=
-	if type systemctl >/dev/null 2>&1; then
-		systemctlcmd=systemctl
-	fi
-	if [ "\\\$systemctlcmd" != "" ]; then
+	systemctlcmd=\\`command -v systemctl 2>/dev/null\\`
+	if [ -x "\\\$systemctlcmd" ]; then
 		\\\$systemctlcmd stop usermin >/dev/null 2>&1 </dev/null
 		rm -f /usr/lib/systemd/system/usermin.service
 		\\\$systemctlcmd daemon-reload
@@ -257,15 +254,12 @@ if [ "\$1" = 0 ]; then
 	if [ "\$?" = 0 ]; then
 		# RPM is being removed, and no new version of usermin
 		# has taken it's place. Delete the config files
-		if type semanage >/dev/null 2>&1; then
+		if command -v semanage >/dev/null 2>&1; then
 			semanage fcontext -d "/var/usermin(/.*)?" >/dev/null 2>&1 || true
 		fi
 		rm -rf /etc/usermin /var/usermin
-		systemctlcmd=
-		if type systemctl >/dev/null 2>&1; then
-			systemctlcmd=systemctl
-		fi
-		if [ "\$systemctlcmd" != "" ]; then
+		systemctlcmd=\`command -v systemctl 2>/dev/null\`
+		if [ -x "\$systemctlcmd" ]; then
 			\$systemctlcmd stop usermin >/dev/null 2>&1 </dev/null
 			rm -f /usr/lib/systemd/system/usermin.service
 			\$systemctlcmd daemon-reload

--- a/makerpm.pl
+++ b/makerpm.pl
@@ -207,8 +207,11 @@ if [ "\\\$answer" = "y" ]; then
 	echo "Removing Usermin RPM .."
 	rm -f /usr/libexec/usermin/authentic-theme/manifest-*
 	rpm -e --nodeps usermin
-	systemctlcmd=\\\`which systemctl 2>/dev/null\\\`
-	if [ -x "\\\$systemctlcmd" ]; then
+	systemctlcmd=
+	if type systemctl >/dev/null 2>&1; then
+		systemctlcmd=systemctl
+	fi
+	if [ "\\\$systemctlcmd" != "" ]; then
 		\\\$systemctlcmd stop usermin >/dev/null 2>&1 </dev/null
 		rm -f /usr/lib/systemd/system/usermin.service
 		\\\$systemctlcmd daemon-reload
@@ -254,12 +257,15 @@ if [ "\$1" = 0 ]; then
 	if [ "\$?" = 0 ]; then
 		# RPM is being removed, and no new version of usermin
 		# has taken it's place. Delete the config files
-		if command -v semanage >/dev/null 2>&1; then
+		if type semanage >/dev/null 2>&1; then
 			semanage fcontext -d "/var/usermin(/.*)?" >/dev/null 2>&1 || true
 		fi
 		rm -rf /etc/usermin /var/usermin
-		systemctlcmd=\`which systemctl 2>/dev/null\`
-		if [ -x "\$systemctlcmd" ]; then
+		systemctlcmd=
+		if type systemctl >/dev/null 2>&1; then
+			systemctlcmd=systemctl
+		fi
+		if [ "\$systemctlcmd" != "" ]; then
 			\$systemctlcmd stop usermin >/dev/null 2>&1 </dev/null
 			rm -f /usr/lib/systemd/system/usermin.service
 			\$systemctlcmd daemon-reload

--- a/setup.sh
+++ b/setup.sh
@@ -600,17 +600,14 @@ ln -s $config_dir/.restart-by-force-kill-init $config_dir/restart-by-force-kill 
 ln -s $config_dir/.reload-init $config_dir/reload >/dev/null 2>&1
 
 # For systemd create different start/stop scripts
-systemctlcmd=
-if type systemctl >/dev/null 2>&1; then
-	systemctlcmd=systemctl
-fi
-if [ "$systemctlcmd" != "" ]; then
+systemctlcmd=`command -v systemctl 2>/dev/null`
+if [ -x "$systemctlcmd" ]; then
 	initsys=`cat /proc/1/comm 2>/dev/null`
 	if [ "$initsys" != "systemd" ]; then
 		systemctlcmd=
 	fi
 fi
-if [ "$systemctlcmd" != "" ]; then
+if [ -x "$systemctlcmd" ]; then
 	rm -f $config_dir/stop $config_dir/start $config_dir/restart $config_dir/restart-by-force-kill $config_dir/reload
 
 	echo "Creating start and stop scripts (systemd) .."
@@ -744,15 +741,12 @@ if [ "\$answer" = "y" ]; then
 	echo "Deleting $config_dir .."
 	rm -rf "$config_dir"
 	echo "Deleting $var_dir .."
-	if [ "$var_dir" = "/var/usermin" ] && type semanage >/dev/null 2>&1; then
+	if [ "$var_dir" = "/var/usermin" ] && command -v semanage >/dev/null 2>&1; then
 		semanage fcontext -d "/var/usermin(/.*)?" >/dev/null 2>&1 || true
 	fi
 	rm -rf "$var_dir"
-	systemctlcmd=
-	if type systemctl >/dev/null 2>&1; then
-		systemctlcmd=systemctl
-	fi
-	if [ "\$systemctlcmd" != "" ]; then
+	systemctlcmd=\`command -v systemctl 2>/dev/null\`
+	if [ -x "\$systemctlcmd" ]; then
 		echo "Deleting usermin.service .."
 		\$systemctlcmd stop usermin >/dev/null 2>&1 </dev/null
 		rm -f /lib/systemd/system/usermin.service /usr/lib/systemd/system/usermin.service
@@ -789,21 +783,21 @@ fix_selinux_var_dir()
 	/var/usermin) ;;
 	*) return 0 ;;
 	esac
-	if ! type selinuxenabled >/dev/null 2>&1 ||
+	if ! command -v selinuxenabled >/dev/null 2>&1 ||
 	   ! selinuxenabled >/dev/null 2>&1; then
 		return 0
 	fi
 	restored=0
-	if type semanage >/dev/null 2>&1; then
+	if command -v semanage >/dev/null 2>&1; then
 		if semanage fcontext -m -t var_run_t "$selinux_var_dir(/.*)?" >/dev/null 2>&1 ||
 		   semanage fcontext -a -t var_run_t "$selinux_var_dir(/.*)?" >/dev/null 2>&1; then
-			if type restorecon >/dev/null 2>&1; then
+			if command -v restorecon >/dev/null 2>&1; then
 				restorecon -R "$selinux_var_dir" >/dev/null 2>&1 && restored=1
 			fi
 		fi
 	fi
 	# chcon is an immediate fallback only; semanage above makes it persistent.
-	if [ "$restored" != "1" ] && type chcon >/dev/null 2>&1; then
+	if [ "$restored" != "1" ] && command -v chcon >/dev/null 2>&1; then
 		chcon -R -t var_run_t "$selinux_var_dir" >/dev/null 2>&1 || true
 	fi
 	return 0

--- a/setup.sh
+++ b/setup.sh
@@ -735,6 +735,9 @@ if [ "\$answer" = "y" ]; then
 	echo "Deleting $config_dir .."
 	rm -rf "$config_dir"
 	echo "Deleting $var_dir .."
+	if [ "$var_dir" = "/var/usermin" ] && command -v semanage >/dev/null 2>&1; then
+		semanage fcontext -d "/var/usermin(/.*)?" >/dev/null 2>&1 || true
+	fi
 	rm -rf "$var_dir"
 	systemctlcmd=\`which systemctl 2>/dev/null\`
 	if [ -x "\$systemctlcmd" ]; then
@@ -766,6 +769,34 @@ fi
 chmod 600 $config_dir/miniserv.pem 2>/dev/null
 echo ".. done"
 echo ""
+
+fix_selinux_var_dir()
+{
+	selinux_var_dir="$1"
+	case "$selinux_var_dir" in
+	/var/usermin) ;;
+	*) return 0 ;;
+	esac
+	if ! command -v selinuxenabled >/dev/null 2>&1 ||
+	   ! selinuxenabled >/dev/null 2>&1; then
+		return 0
+	fi
+	restored=0
+	if command -v semanage >/dev/null 2>&1; then
+		if semanage fcontext -m -t var_run_t "$selinux_var_dir(/.*)?" >/dev/null 2>&1 ||
+		   semanage fcontext -a -t var_run_t "$selinux_var_dir(/.*)?" >/dev/null 2>&1; then
+			if command -v restorecon >/dev/null 2>&1; then
+				restorecon -R "$selinux_var_dir" >/dev/null 2>&1 && restored=1
+			fi
+		fi
+	fi
+	# chcon is an immediate fallback only; semanage above makes it persistent.
+	if [ "$restored" != "1" ] && command -v chcon >/dev/null 2>&1; then
+		chcon -R -t var_run_t "$selinux_var_dir" >/dev/null 2>&1 || true
+	fi
+	return 0
+}
+fix_selinux_var_dir "$var_dir"
 
 # Save target directory if one was specified
 if [ "$wadir" != "$srcdir" ]; then

--- a/setup.sh
+++ b/setup.sh
@@ -600,8 +600,17 @@ ln -s $config_dir/.restart-by-force-kill-init $config_dir/restart-by-force-kill 
 ln -s $config_dir/.reload-init $config_dir/reload >/dev/null 2>&1
 
 # For systemd create different start/stop scripts
-systemctlcmd=`which systemctl 2>/dev/null`
-if [ -x "$systemctlcmd" ]; then
+systemctlcmd=
+if type systemctl >/dev/null 2>&1; then
+	systemctlcmd=systemctl
+fi
+if [ "$systemctlcmd" != "" ]; then
+	initsys=`cat /proc/1/comm 2>/dev/null`
+	if [ "$initsys" != "systemd" ]; then
+		systemctlcmd=
+	fi
+fi
+if [ "$systemctlcmd" != "" ]; then
 	rm -f $config_dir/stop $config_dir/start $config_dir/restart $config_dir/restart-by-force-kill $config_dir/reload
 
 	echo "Creating start and stop scripts (systemd) .."
@@ -735,12 +744,15 @@ if [ "\$answer" = "y" ]; then
 	echo "Deleting $config_dir .."
 	rm -rf "$config_dir"
 	echo "Deleting $var_dir .."
-	if [ "$var_dir" = "/var/usermin" ] && command -v semanage >/dev/null 2>&1; then
+	if [ "$var_dir" = "/var/usermin" ] && type semanage >/dev/null 2>&1; then
 		semanage fcontext -d "/var/usermin(/.*)?" >/dev/null 2>&1 || true
 	fi
 	rm -rf "$var_dir"
-	systemctlcmd=\`which systemctl 2>/dev/null\`
-	if [ -x "\$systemctlcmd" ]; then
+	systemctlcmd=
+	if type systemctl >/dev/null 2>&1; then
+		systemctlcmd=systemctl
+	fi
+	if [ "\$systemctlcmd" != "" ]; then
 		echo "Deleting usermin.service .."
 		\$systemctlcmd stop usermin >/dev/null 2>&1 </dev/null
 		rm -f /lib/systemd/system/usermin.service /usr/lib/systemd/system/usermin.service
@@ -777,21 +789,21 @@ fix_selinux_var_dir()
 	/var/usermin) ;;
 	*) return 0 ;;
 	esac
-	if ! command -v selinuxenabled >/dev/null 2>&1 ||
+	if ! type selinuxenabled >/dev/null 2>&1 ||
 	   ! selinuxenabled >/dev/null 2>&1; then
 		return 0
 	fi
 	restored=0
-	if command -v semanage >/dev/null 2>&1; then
+	if type semanage >/dev/null 2>&1; then
 		if semanage fcontext -m -t var_run_t "$selinux_var_dir(/.*)?" >/dev/null 2>&1 ||
 		   semanage fcontext -a -t var_run_t "$selinux_var_dir(/.*)?" >/dev/null 2>&1; then
-			if command -v restorecon >/dev/null 2>&1; then
+			if type restorecon >/dev/null 2>&1; then
 				restorecon -R "$selinux_var_dir" >/dev/null 2>&1 && restored=1
 			fi
 		fi
 	fi
 	# chcon is an immediate fallback only; semanage above makes it persistent.
-	if [ "$restored" != "1" ] && command -v chcon >/dev/null 2>&1; then
+	if [ "$restored" != "1" ] && type chcon >/dev/null 2>&1; then
 		chcon -R -t var_run_t "$selinux_var_dir" >/dev/null 2>&1 || true
 	fi
 	return 0


### PR DESCRIPTION
Hello Jamie,

This PR adds SELinux context handling for Usermin’s default runtime directory on EL systems.

Setup now persists and applies a `var_run_t` fcontext rule when SELinux is enabled, falls back safely when SELinux tooling is unavailable, and removes the local fcontext rule when `/var/usermin` is deleted during uninstall.

Discussed originally here:
https://forum.virtualmin.com/t/usermin-needs-selinux-fix/137474